### PR TITLE
[RequestInfo] 레이아웃 및 기본적인 기능 구현 완료

### DIFF
--- a/src/components/DeliveryManagement/RequestInfo.js
+++ b/src/components/DeliveryManagement/RequestInfo.js
@@ -1,5 +1,227 @@
-function DeliveryRequestInfo() {
-  return <section>Request Info Section</section>;
+import { useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import CardContent from '@mui/material/CardContent';
+
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+
+const DELIVERY_STATUS = ['출고 요청', '출고 대기', '출고 완료', '배송 완료'];
+const DELIVERY_TYPES = [
+  '아침(08:00) 출고',
+  '오전(10:00) 출고',
+  '정오(12:00) 출고',
+  '오후(14:00) 출고',
+  '오후(16:00) 출고',
+];
+
+function getStyles(type, deliveryType, theme) {
+  return {
+    fontWeight:
+      deliveryType.indexOf(type) === -1
+        ? theme.typography.fontWeightRegular
+        : theme.typography.fontWeightMedium,
+  };
 }
 
-export default DeliveryRequestInfo;
+export default function RequestInfo() {
+  const theme = useTheme();
+  const [deliveryStatus, setDeliveryStatus] = useState(DELIVERY_STATUS[0]);
+  const [deliveryType, setDeliveryType] = useState(DELIVERY_TYPES[1]);
+
+  const handleChange = event => {
+    const { name, value } = event.target;
+    if (name === 'deliveryStatus') {
+      setDeliveryStatus(value);
+    } else if (name === 'deliveryType') {
+      setDeliveryType(value);
+    }
+  };
+
+  return (
+    <Card component="section" sx={{ mt: 2, p: 1 }}>
+      <CardHeader
+        component="h5"
+        title="출고 신청 정보"
+        subheader="September 14, 2016"
+        sx={{ mt: 1, mb: -2 }}
+        titleTypographyProps={{ variant: 'h5', fontWeight: '600' }}
+      />
+
+      <CardContent>
+        <Grid container>
+          <Grid container item xs={5.5} spacing={4} sx={{ px: 1 }}>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                전표 번호
+                <TextField
+                  defaultValue="OODNLQC001202201170003"
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '275px' }}
+                />
+              </label>
+            </Grid>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                요청 일자
+                <TextField
+                  defaultValue="2022-01-18"
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '125px' }}
+                />
+              </label>
+            </Grid>
+          </Grid>
+
+          <Grid container item xs={6.5} spacing={4} sx={{ px: 1 }}>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                요청 업체
+                <TextField
+                  defaultValue="콜로세움 코퍼레이션"
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '175px' }}
+                />
+              </label>
+            </Grid>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                요청 담당
+                <TextField
+                  defaultValue="support@colosseum.kr"
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '225px' }}
+                />
+              </label>
+            </Grid>
+          </Grid>
+        </Grid>
+
+        <Grid container>
+          <Grid container item xs={6.5} spacing={4} sx={{ px: 1 }}>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                출고 방식
+                <TextField
+                  defaultValue="택배"
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '100px' }}
+                />
+              </label>
+            </Grid>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                출고 상태
+                <Select
+                  defaultValue={deliveryStatus}
+                  onChange={handleChange}
+                  value={deliveryStatus}
+                  name="deliveryStatus"
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '125px' }}
+                >
+                  {DELIVERY_STATUS.map(status => (
+                    <MenuItem
+                      key={status}
+                      value={status}
+                      style={getStyles(status, deliveryStatus, theme)}
+                    >
+                      {status}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </label>
+            </Grid>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                출고 유형
+                <Select
+                  defaultValue={deliveryType}
+                  onChange={handleChange}
+                  value={deliveryType}
+                  name="deliveryType"
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '175px' }}
+                >
+                  {DELIVERY_TYPES.map(type => (
+                    <MenuItem
+                      key={type}
+                      value={type}
+                      style={getStyles(type, deliveryType, theme)}
+                    >
+                      {type}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </label>
+            </Grid>
+          </Grid>
+
+          <Grid container item xs={5.5} spacing={4} sx={{ px: 1 }}>
+            <Grid
+              item
+              sx={{ fontSize: '16px', fontWeight: '600', lineHeight: 3.5 }}
+            >
+              <label>
+                파일명
+                <TextField
+                  defaultValue="테스트_콜로세움주문서_test.xls"
+                  InputProps={{ readOnly: true }}
+                  size="small"
+                  margin="dense"
+                  sx={{ ml: 2, width: '275px' }}
+                />
+              </label>
+            </Grid>
+            <Grid item sx={{ lineHeight: 3.3 }}>
+              <Button
+                variant="contained"
+                sx={{ width: '105px', fontSize: '16px', fontWeight: 'bold' }}
+              >
+                변경 완료
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/DeliveryManagement.js
+++ b/src/pages/DeliveryManagement.js
@@ -1,13 +1,12 @@
+import Container from '@mui/material/Container';
 import DeliveryRequestInfo from 'components/DeliveryManagement/RequestInfo';
 import DeliveryRequestList from 'components/DeliveryManagement/RequestList';
 
-function DeliveryManagement() {
+export default function DeliveryManagement() {
   return (
-    <main>
+    <Container component="main" maxWidth="xl">
       <DeliveryRequestInfo />
       <DeliveryRequestList />
-    </main>
+    </Container>
   );
 }
-
-export default DeliveryManagement;


### PR DESCRIPTION
## 구현 화면

<img width="1920" alt="week3_21" src="https://user-images.githubusercontent.com/72926450/154784307-00cb50be-5837-4b01-b85a-609aa5ad9207.png">


## 구현 범위

### 주요 구현 사항
- 기본적으로 MUI 라이브러리에 내장되어 있는 기본적인 Grid System, Data Table 등의 컴포넌트 적극 활용
- **출고 신청 정보**(`RequestInfo` 컴포넌트)
  - MUI 내장 컴포넌트 중 Card, Grid 등을 활용하여 기존의 정방형 레이아웃을 가로 형태의 레이아웃으로 수정
  - 출고 신청 정보 중 일부 정보에 한해, 직접 정보를 수정할 수 있게 하기 위하여 간단한 Select Box 기능 구현